### PR TITLE
Rename BjoernPetersen/scoop-bucket search

### DIFF
--- a/maintenance/github-crawler.py
+++ b/maintenance/github-crawler.py
@@ -162,7 +162,7 @@ searches.append({
         '82p/scoop-yubico-bucket',
         'Aaike/scoop',
         'Alxandr/scoop-bucket',
-        'BjoernPetersen/scoop-bucket',
+        'BjoernPetersen/scoop-misc-bucket',
         'Callidin/ragnar-scoop',
         'Congee/barrel',
         'DimiG/dgBucket',


### PR DESCRIPTION
The repo was renamed to BjoernPetersen/scoop-misc-bucket a while ago.