### PR TITLE
handle bucket subdirectory for all repos

### DIFF
--- a/maintenance/github-crawler.py
+++ b/maintenance/github-crawler.py
@@ -627,13 +627,10 @@ def do_repo(repo, i, num_repos, do_score=True):
         return 0
 
     cache[repofoldername]['entries'] = []
-    bucket_repos = ['lukesampson/scoop', 'lukesampson/scoop-extras', 'scoopinstaller/versions']
-    if full_name in bucket_repos:
-        bucket = '/bucket'
-    else:
-        bucket = ''
-
-    bucket_path = os.path.join(cache_dir, repofoldername) + bucket
+    
+    bucket_path = os.path.join(cache_dir, repofoldername)
+    if os.path.isdir(bucket_path + '/bucket'):
+        bucket_path = bucket_path + '/bucket'
 
     rows = {}
 

--- a/maintenance/github-crawler.py
+++ b/maintenance/github-crawler.py
@@ -628,8 +628,10 @@ def do_repo(repo, i, num_repos, do_score=True):
 
     cache[repofoldername]['entries'] = []
     
+    bucket = ''
     bucket_path = os.path.join(cache_dir, repofoldername)
     if os.path.isdir(bucket_path + '/bucket'):
+        bucket = '/bucket'
         bucket_path = bucket_path + '/bucket'
 
     rows = {}


### PR DESCRIPTION
Many community buckets have changed the structure to use `bucket` subdirectory.
https://github.com/Ash258/scoop-Ash258
https://github.com/lukesampson/scoop-extras/commit/ff7c24db0945c3e315b74c648d2d4ad51b2820b5
https://github.com/h404bi/dorado/commit/87b9eccce598f488389633dfa2019b841f502107
