### PR TITLE
Add littleli/scoop-clojure

### DIFF
--- a/maintenance/github-crawler.py
+++ b/maintenance/github-crawler.py
@@ -218,6 +218,7 @@ searches.append({
         'kodybrown/scoop-nirsoft',
         'liaoya/scoop-bucket',
         'lillicoder/scoop-openjdk6',
+        'littleli/scoop-clojure',
         'lptstr/open-scoop',
         # 'lukesampson/scoop',
         'lukesampson/scoop-extras',


### PR DESCRIPTION
This scoop bucket contains the installation procedure for the recent version of Clojure along with other community utilities.