### PR TITLE
Remove clone of scoopinstaller/scoop-main

### DIFF
--- a/include.txt
+++ b/include.txt
@@ -83,7 +83,6 @@ https://github.com/pigsflew/scoop-arbitrariae.git
 https://github.com/prezesp/scoop-viewer-bucket.git
 https://github.com/rasa/scoops.git
 https://github.com/rcqls/scoop-extras.git
-https://github.com/rivy/scoop.bucket-scoop.main.git
 https://github.com/rkolka/scoop-manifold.git
 https://github.com/Sandex/scoop-supernova.git
 https://github.com/se35710/scoop-ibm.git


### PR DESCRIPTION
https://github.com/rivy/scoop.bucket-scoop.main.git is a clone of scoopinstaller/scoop-main and is listed in the [exclude list#805](https://github.com/rasa/scoop-directory/blob/12d4a9b4c51f6239db1a585759f63712408fa72f/exclude.txt#L805) with a slightly different name (repo was probably renamed)