### PR TITLE
Add bucket gendloop/gendloopBucket to include.txt

### DIFF
--- a/include.txt
+++ b/include.txt
@@ -1,4 +1,5 @@
 url
+https://github.com/gendloop/gendloopBucket.git
 https://github.com/okibcn/Bucket.git
 https://github.com/82p/scoop-yubico-bucket.git
 https://github.com/Alxandr/scoop-bucket.git


### PR DESCRIPTION
[This bucket](https://github.com/gendloop/gendloopBucket) collects some of my commonly used applications and [how to use](https://github.com/gendloop/gendloopBucket/wiki) them. Some applications are listed in [this repo](https://github.com/gendloop/gendloopApps), hoping to help more people