### PR TITLE
Add wheels-dev/scoop-wheels

### DIFF
--- a/include.txt
+++ b/include.txt
@@ -105,3 +105,4 @@ https://github.com/quawy/stash-bucket.git
 https://github.com/naveed-patel/NScooP.git
 https://github.com/Befod/Xeno.git
 https://github.com/danalec/scoop-alts.git
+https://github.com/wheels-dev/scoop-wheels.git


### PR DESCRIPTION
Adds the Scoop bucket for [Wheels](https://wheels.dev), an open-source CFML MVC framework (similar layout to Rails/Laravel) and its [CLI](https://github.com/wheels-dev/wheels).

The bucket ships two channels — both depend on `java/openjdk21` and expose a `wheels` shim:
- `wheels` — stable, tracks GA tags on [wheels-dev/wheels](https://github.com/wheels-dev/wheels)
- `wheels-be` — bleeding-edge, tracks `*-snapshot.*` pre-releases on [wheels-dev/wheels-snapshots](https://github.com/wheels-dev/wheels-snapshots) (every merge to `develop`)

Mutual exclusion is enforced via the shared `wheels` shim — Scoop refuses to install both. Bucket layout follows the standard `bucket/<manifest>.json` convention. Repo: https://github.com/wheels-dev/scoop-wheels